### PR TITLE
feat: Add VS Code launch and tasks configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,5 +3,20 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
-    "configurations": []
+    "configurations": [
+        {
+            "name": "C++ Debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/main",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb",
+            "preLaunchTask": "build"
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "cmake -S . -B build && cmake --build build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$gcc"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds `.vscode/launch.json` and `.vscode/tasks.json` to provide a seamless build and debug experience in Visual Studio Code.

The `tasks.json` file defines a "build" task that uses CMake to compile the C++ project.

The `launch.json` file defines a "C++ Debug" configuration that:
- Runs the "build" task as a `preLaunchTask`.
- Launches the debugger on the compiled executable.
- Is configured to work with GDB.